### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,8 @@ Depends: methods, magrittr, formatters (>= 0.3.0), R (>= 2.10)
 Imports:
   stats,
   htmltools,
+  flextable,
+  officer,
   grid
 Suggests:
   dplyr,
@@ -27,9 +29,7 @@ Suggests:
   testthat,
   xml2,
   knitr,
-  rmarkdown,
-  flextable,
-  officer
+  rmarkdown
 License: Apache License 2.0 | file LICENSE
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
`flextable` and `officer` packages should be moved to Imports, because `tt_to_flextable` is used in test
https://github.com/Roche/rtables/blob/pre-release/R/tt_export.R#L178
https://github.com/Roche/rtables/blob/32fecf37c090c843d3eb93f14fa2208a80ff1ff9/tests/testthat/test-exporters.R#L76