### PR TITLE
Review vignettes to improve readability

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -89,7 +89,7 @@ found in the [releases list](https://github.com/insightsengineering/rtables/rele
 We first begin with a demographic table alike example and then show the creation of a more complex table.
 
 
-```{r}
+```{r, message=FALSE}
 library(rtables)
 
 lyt <- basic_table() %>%
@@ -105,7 +105,7 @@ lyt <- basic_table() %>%
     } else if (is.factor(x) || is.character(x)) {
       in_rows(.list = list_wrap_x(table)(x))
     } else {
-      stop("type not supproted")
+      stop("type not supported")
     }
   })
 
@@ -113,7 +113,7 @@ build_table(lyt, ex_adsl)
 ```
 
 
-```{r}
+```{r, message=FALSE}
 library(rtables)
 library(dplyr)
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -26,7 +26,7 @@ articles:
     - title_footer
     - custom_appearance
     - advanced_usage
-    - formats_precedence
+    - format_precedence
 
 reference:
 

--- a/vignettes/baseline.Rmd
+++ b/vignettes/baseline.Rmd
@@ -35,7 +35,7 @@ Often the data from one column is considered the reference/baseline/comparison g
 
 For example, lets calculate the average age:
 
-```{r}
+```{r, message=FALSE}
 library(rtables)
 
 lyt <- basic_table() %>%
@@ -115,6 +115,6 @@ tbl5 <- build_table(lyt5, subset(DM, SEX %in% c("M", "F")))
 tbl5
 ```
 
-so the data assigned to `.ref_full` is the full data of the reference column where the data assigned to `.ref_group` respects the subsetting defined by row-splitting and hence is from the same subset as the argument `x` or `df` to `afun`.
+The data assigned to `.ref_full` is the full data of the reference column whereas the data assigned to `.ref_group` respects the subsetting defined by row-splitting and hence is from the same subset as the argument `x` or `df` to `afun`.
 
 

--- a/vignettes/format_precedence.Rmd
+++ b/vignettes/format_precedence.Rmd
@@ -1,10 +1,10 @@
 ---
-title: "Formats Precedence and NA Handling"
+title: "Format Precedence and NA Handling"
 author: "Wojciech Wójciak and Gabriel Becker"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Formats Precedence NA Handling}
+  %\VignetteIndexEntry{Format Precedence and NA Handling}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
 editor_options: 
@@ -23,29 +23,24 @@ knitr::opts_chunk$set(comment = "#")
 
 ## Formats Precedence
 
-A user of `rtables` package can specify the format in which the
-numbers in the reporting tables are printed. Formatting functionally
+Users of the `rtables` package can specify the format in which the
+numbers in the reporting tables are printed. Formatting functionality
 is provided by the
 [`formatters`](https://insightsengineering.github.io/formatters/) R
-package and available formats can be listed with
-`formatters::list_valid_format_labels()` function.  The format can be
-specified by the user in a few different places. It may happen that
+package. See `formatters::list_valid_format_labels()` for a list of 
+all available formats. The format can be
+specified by the user in a few different places. It may happen that,
 for a single table layout, the format is specified in more than one
 place. In such a case, the final format that will be applied depends
-on formats precedence rules defined by `rtables`. In this vignette, we
-describe the basic rules of `rtables` formats precedence.
+on format precedence rules defined by `rtables`. In this vignette, we
+describe the basic rules of `rtables` format precedence.
 
-The packages used in this vignette are:
+The examples shown in this vignette utilize the example ADSL
+dataset, a demographic table that summarizes the variables
+content for different population subsets (encoded in the columns).
 
 ```{r, message=FALSE}
 library(rtables)
-```
-
-The examples shown in this vignette are based on the example `ADSL`
-dataset, i.e. a demographic table that summarizes the variables
-content for different population subsets (encoded in the columns).
-
-```{r}
 ADSL <- ex_adsl
 ```
 
@@ -56,22 +51,23 @@ package and was created using the publicly available
 [`random.cdisc.data`](https://insightsengineering.github.io/random.cdisc.data/)
 R package.
 
-### Formats precedence and inheritance rules
+### Format Precedence and Inheritance Rules
 
 The format in which numbers are printed can be specified by the user
-in a few different places. In the context of the precedence, it is
-important at which level of the split hierarchy formats are
-specified. In general, there are two such levels: the **cell** level
-or the so-called **parent table** level. The concept of the cell and
-the parent table results from the way in which `rtables` package
+in a few different places. In the context of precedence, it is
+important which level of the split hierarchy formats are specified 
+at. In general, there are two such levels: the **cell** level
+and the so-called **parent table** level. The concept of the cell and
+the parent table results from the way in which the `rtables` package
 stores resulting tables. It models the resulting tables as
 hierarchical, tree-like objects with the cells (as leaves) containing
 multiple values. Particularly noteworthy in this context is the fact
-that the actual table splitting occurs in a row-dominant way (even if
-the column split is present in the layout). `rtables` provides
+that the actual table splitting occurs in a row-dominant way (even if 
+column splitting is present in the layout). `rtables` provides
 user-end function `table_structure()` that prints the structure of a
-given table object. For a quick illustration, consider the following
-example.
+given table object. 
+
+For a simple illustration, consider the following example:
 
 ```{r}
 lyt <- basic_table() %>%
@@ -84,37 +80,37 @@ adsl_analyzed
 table_structure(adsl_analyzed)
 ```
 
-For this reporting table, there are 4 sub-tables under `SEX`
-table. These are: `F`, `M`, `U`, and `UNDIFFERENTIATED`. Each of these
-sub-tables has one sub-table `AGE`. So, e.g. for the top sub-table
-`AGE`, its nearest parent table is `F`.
+In this table, there are 4 sub-tables under the `SEX` table. 
+These are: `F`, `M`, `U`, and `UNDIFFERENTIATED`. Each of these
+sub-tables has one sub-table `AGE`. For example, for the first 
+`AGE` sub-table, its parent table is `F`.
 
-The concept of hierarchical, tree-like representation of resulting
-tables, translates directly to formats precedence and inheritance
+The concept of hierarchical, tree-like representations of resulting
+tables translates directly to format precedence and inheritance
 rules. As a general principle, the format being finally applied for
 the cell is the one that is the most specific, that is, the one which
-is the closest to that cell in a given path in the tree. Hence, the
-precedence-inheritance chain looks like below.
+is the closest to the cell in a given path in the tree. Hence, the
+precedence-inheritance chain looks like the following:
 
 ```
-cell <- parent_table <- parent_table <- ... <- parent_table
+parent_table -> parent_table -> ... -> parent_table -> cell
 ```
 
-In such a chain, the most outer `parent_table` is the least specific
+In such a chain, the outermost `parent_table` is the least specific
 place to specify the format, while the `cell` is the most specific
-one. In case the format is specified by the user in more than one
-place, the one which is more specific will be applied for the cell. If
-no specific format has been selected by the user for the split, then
-the default format will be applied. The default format is "xx" and it
-yields the same formatting as `as.character()` function. In the
+one. In cases where the format is specified by the user in more than 
+one place, the one which is most specific will be applied in the cell.
+If no specific format has been selected by the user for the split, then
+the default format will be applied. The default format is `"xx"` and it
+yields the same formatting as the `as.character()` function. In the
 following sections of this vignette, we will illustrate the format
 precedence rules with a few examples.
 
-### Standard format
+### Standard Format
 
-Below is a simple layout that does not explicitly set any specific
-format for the output of the analysis function used in this
-example. In such a case, the default format will be used.
+Below is a simple layout that does not explicitly set a format for the 
+output of the analysis function. In such a case, the default format 
+is applied.
 
 ```{r}
 lyt0 <- basic_table() %>%
@@ -124,12 +120,12 @@ lyt0 <- basic_table() %>%
 build_table(lyt0, ADSL)
 ```
 
-### Cell format
+### Cell Format
 
-The format of the cell can be explicitly specified through `rcell()`
+The format of a cell can be explicitly specified via the `rcell()`
 or `in_rows()` functions. The former is essentially a collection of
 data objects while the latter is a collection of `rcell()` objects. As
-already mentioned, this is the most specific place where the format
+previously mentioned, this is the most specific place where the format
 can be specified by the user.
 
 ```{r}
@@ -154,12 +150,12 @@ build_table(lyt1a, ADSL)
 ```
 
 If the format is specified in both of these places at the same time,
-the one specified through `in_rows()`, has higher
-precedence. Technically, in this case, the format defined in `rcell()`
-will simply be overwritten by the one defined in `in_rows()`. This is
+the one specified via `in_rows()` takes highest precedence. 
+Technically, in this case, the format defined in `rcell()` will simply 
+be overwritten by the one defined in `in_rows()`. This is
 because the format specified in `in_rows()` is applied to the cells
-not the rows (overriding the previously specified cell specific
-values), which means that the precedence rules described above are
+not the rows (overriding the previously specified cell-specific
+values), which indicates that the precedence rules described above are
 still in place.
 
 ```{r}
@@ -175,12 +171,12 @@ lyt2 <- basic_table() %>%
 build_table(lyt2, ADSL)
 ```
 
-### Parent table format and inheritance
+### Parent Table Format and Inheritance
 
 In addition to the cell level, the format can be specified at the
-parent table level. Then, if no format has been set by the user for a
-cell, the most specific format for that cell is the one defined at the
-nearest parent split table (if any).
+parent table level. If no format has been set by the user for a cell, 
+the most specific format for that cell is the one defined at its
+innermost parent table split (if any).
 
 ```{r}
 lyt3 <- basic_table() %>%
@@ -190,9 +186,9 @@ lyt3 <- basic_table() %>%
 build_table(lyt3, ADSL)
 ```
 
-If the cell format was specified too, then the parent table format is
-ignored for this cell, since the cell format is treated as more
-specific.
+If the cell format is also specified for a cell, then the parent table 
+format is ignored for this cell since the cell format is more specific
+and therefore takes precedence.
 
 ```{r}
 lyt4 <- basic_table() %>%
@@ -222,9 +218,9 @@ lyt4a <- basic_table() %>%
 build_table(lyt4a, ADSL)
 ```
 
-In the following, slightly more complicated example, we can observe
-partial inheritance. That is, only `SD` cell inherits the parent
-table's format, while the `Mean` cell does not.
+In the following, slightly more complicated, example, we can observe
+partial inheritance. That is, only `SD` cells inherit the parent
+table's format while the `Mean` cells do not.
 
 ```{r}
 lyt5 <- basic_table() %>%
@@ -255,19 +251,19 @@ lyt6 <- basic_table() %>%
 build_table(lyt6, ADSL)
 ```
 
-In the output, the cell corresponding to `UNDIFFERENTIATED` level of
-`SEX` and `B: Placebo drug` level of `ARM` categorical variables is
-displayed as `NA`. This happened because there were no non-`NA` values
-under this facet to compute the mean. `rtables` allows the user to
+In the output the cell corresponding to the `UNDIFFERENTIATED` level 
+of `SEX` and the `B: Placebo` level of `ARM` is displayed as `NA`. 
+This occurs because there were no non-`NA` values under this facet 
+that could be used to compute the mean. `rtables` allows the user to
 specify a string to display when cell values are `NA`. Similar to
 formats for numbers, the user can specify a string to replace `NA`
 with the parameter `format_na_str` or `.format_na_str`. This can be
-specified at the **cell** or **parent table** level. The `NA` string
+specified at the cell or parent table level. `NA` string
 precedence and inheritance rules are the same as those for number
-formats precedence, described in the previous section of this
-vignette. We will illustrate them with a few examples.
+format precedence, described in the previous section of this
+vignette. We will illustrate this with a few examples.
 
-### Replacing `NA` values at the cell level
+### Replacing `NA` Values at the Cell Level
 
 At the cell level, it is possible to replace `NA` values with a custom
 string by means of the `format_na_str` parameter in `rcell()` or
@@ -297,11 +293,11 @@ build_table(lyt7a, ADSL)
 ```
 
 If the `NA` string is specified in both of these places at the same
-time, the one specified with `in_rows()`, has higher
-precedence. Technically, in this case, the `NA` replacement string
+time, the one specified with `in_rows()` takes precedence. 
+Technically, in this case the `NA` replacement string
 defined in `rcell()` will simply be overwritten by the one defined in
 `in_rows()`. This is because the `NA` string specified in `in_rows()`
-is applied to the cells not the rows (overriding the previously
+is applied to the cells, not the rows (overriding the previously
 specified cell specific values), which means that the precedence rules
 described above are still in place.
 
@@ -319,13 +315,13 @@ lyt8 <- basic_table() %>%
 build_table(lyt8, ADSL)
 ```
 
-### Parent table replacement of `NA` values and inheritance principles
+### Parent Table Replacement of `NA` Values and Inheritance Principles
 
 In addition to the cell level, the string replacement for `NA` values
-can be specified at the parent table level. Then, if no replacement
+can be specified at the parent table level. If no replacement
 string has been specified by the user for a cell, the most specific
-`NA` string for that cell is the one defined at the nearest parent
-split table (if any).
+`NA` string for that cell is the one defined at its innermost parent
+table split (if any).
 
 ```{r}
 lyt9 <- basic_table() %>%
@@ -336,10 +332,10 @@ lyt9 <- basic_table() %>%
 build_table(lyt9, ADSL)
 ```
 
-If the replacement string for `NA` values was specified also at the
+If an `NA` value replacement string was also specified at the
 cell level, then the one set at the parent table level is ignored for
-this cell, as the cell level settings are treated as the most
-specific.
+this cell as the cell level format is more specific and therefore 
+takes precedence.
 
 ```{r}
 lyt10 <- basic_table() %>%
@@ -373,8 +369,8 @@ build_table(lyt10a, ADSL)
 ```
 
 In the following, slightly more complicated example, we can observe
-partial inheritance. That is, only `SD` cell inherits the parent
-table's `NA` string, while the `Mean` cell does not.
+partial inheritance of NA strings. That is, only `SD` cells inherit 
+the parent table's `NA` string, while the `Mean` cells do not.
 
 ```{r}
 lyt11 <- basic_table() %>%

--- a/vignettes/sorting_pruning.Rmd
+++ b/vignettes/sorting_pruning.Rmd
@@ -22,12 +22,12 @@ knitr::opts_chunk$set(comment = "#")
 ```
 ## Introduction
 
-Often we want to filter or reorder subsections of a table in ways that take into account the table structure. For example
+Often we want to filter or reorder subsections of a table in ways that take into account the table structure. For example:
 
-- sorting subtables corresponding to factor levels so that most commonly observed levels occur first in the table
+- Sorting subtables corresponding to factor levels so that most commonly observed levels occur first in the table
 - Removing subtables which represent 0 observations or which after other filtering contain 0 rows
 
-```{r, messages=FALSE}
+```{r, message=FALSE}
 library(rtables)
 library(dplyr)
 ```
@@ -52,7 +52,7 @@ raw_tbl
 
 ## Trimming
 
-### Rows
+### Trimming Rows
 
 Trimming represents a convenience wrapper around simple, direct subsetting of the rows of a `TableTree`.
 
@@ -70,7 +70,7 @@ trim_rows(raw_tbl)
 
 ### Trimming Columns
 
-There are currently no special utilities for trimming columns but we can remove the empty columns with fairly straightforward column subsetting:
+There are currently no special utilities for trimming columns but we can remove the empty columns with fairly straightforward column subsetting using the `col_counts()` function:
 
 ```{r}
 coltrimmed <- raw_tbl[, col_counts(raw_tbl) > 0]
@@ -84,7 +84,7 @@ Pruning is similar in outcome to trimming, but more powerful and more complex, a
 
 Pruning is applied recursively, in that at each structural unit (subtable, row) it applies the pruning function both at that level and to all it's children (up to a user-specifiable maximum depth).
 
-The default pruning function, for example, determines if a subtree is empty by
+The default pruning function, for example, determines if a subtree is empty by:
 
 a. Removing all children which contain a single content row which contains all zeros or all `NA`s
 b. Removing rows which contain either all zeros or all `NA`s
@@ -177,7 +177,7 @@ sort_at_path(silly_tbl, c("cyl", "*", "mpg"), scorefun)
 
 # Writing Custom Pruning Criteria and Scoring Functions
 
-Pruning criteria and scoring functions map TableTree or TableRow objects to a Boolean value (for pruning criteria) or a sortable scalar value (scoring functions). To do this we currently need to interact with the structure of the objects more than usual.
+Pruning criteria and scoring functions map `TableTree` or `TableRow` objects to a Boolean value (for pruning criteria) or a sortable scalar value (scoring functions). To do this we currently need to interact with the structure of the objects more than usual.
 
 ## Useful Functions and Accessors
 
@@ -211,7 +211,7 @@ silly_name_scorer <- function(tt) {
 sort_at_path(ethsort, "RACE", silly_name_scorer)
 ```
 
-**NOTE** generally this would be more appropriately done using the reorder_split_levels function within the layout rather than as a sort post-processing step, but other character scorers may or may not map as easily to layouting directives.
+**NOTE**: Generally this would be more appropriately done using the `reorder_split_levels()` function within the layout rather than as a sort post-processing step, but other character scorers may or may not map as easily to layouting directives.
 
 
 ### Sort by the Percent Difference in Counts Between Genders in Arm C

--- a/vignettes/tabulation_concepts.Rmd
+++ b/vignettes/tabulation_concepts.Rmd
@@ -27,17 +27,15 @@ knitr::opts_chunk$set(comment = "#")
 
 ## Introduction
 
-In this vignette we will introduce some theory behind using layouts for table creation. Much of the theory also holds true when using
+In this vignette we will introduce some theory behind using layouts for table creation. Much of the theory also holds true when using other table packages. For this vignette we will use the following packages:
 
-For this vignette we will use the following packages:
-
-```{r}
+```{r, message=FALSE}
 library(dplyr)
 library(tibble)
 library(rtables)
 ```
 
-The data we use is the following one created with random number generators:
+The data we use is the following, created with random number generators:
 
 ```{r}
 add_subgroup <- function(x) paste0(tolower(x), sample(1:3, length(x), TRUE))
@@ -107,7 +105,7 @@ bar_label        bar(x_A)  bar(x_B)  bar(x_C)
 zoo_label        zoo(x_A)  zoo(x_B)  zoo(x_C)
 ```
 
-where
+where:
 
 ```{r}
 x_A <- df_A$x
@@ -115,7 +113,7 @@ x_B <- df_B$x
 x_C <- df_C$x
 ```
 
-The function passed to `afun` is evaluated using argument matching, if `afun` has an argument `x` the analysis variable specified in `vars` in `analyze()` is passed to the function and if `afun` has an argument `df` then set subset of the dataset is passed to `afun`. So,
+The function passed to `afun` is evaluated using argument matching. If `afun` has an argument `x` the analysis variable specified in `vars` in `analyze()` is passed to the function, and if `afun` has an argument `df` then a subset of the dataset is passed to `afun`:
 
 ```{r}
 lyt2 <- basic_table() %>%
@@ -128,7 +126,7 @@ tbl2 <- build_table(lyt2, df)
 tbl2
 ```
 
-Note that it is also possible that a function returns multiple rows with `in_rows()`
+Note that it is also possible that a function returns multiple rows with `in_rows()`:
 
 ```{r}
 lyt3 <- basic_table() %>%
@@ -150,7 +148,7 @@ tbl3 <- build_table(lyt3, df)
 tbl3
 ```
 
-which is how we recommend to specify the row names explicitly.
+This is how we recommend you specify the row names explicitly.
 
 ## Tabulation With Row Structure
 
@@ -221,7 +219,7 @@ matrix(
 )
 ```
 
-In `rtables` this type of tabulation is done with `layouts`
+In `rtables` this type of tabulation is done with `layouts`:
 
 ```{r}
 lyt4 <- basic_table() %>%
@@ -233,7 +231,7 @@ tbl4 <- build_table(lyt4, df)
 tbl4
 ```
 
-or if we would not want to see the `foo` label we would have to use
+or if we would not want to see the `foo` label we would have to use:
 
 ```{r}
 lyt5 <- basic_table() %>%
@@ -245,7 +243,7 @@ tbl5 <- build_table(lyt5, df)
 tbl5
 ```
 
-but now the row labels disappeared. This is because `cfun` needs to define it's row label. So let's redefine `foo`:
+but now the row labels have disappeared. This is because `cfun` needs to define its row label. So let's redefine `foo`:
 
 
 ```{r}
@@ -265,7 +263,7 @@ tbl6
 
 ### Calculating the Mean
 
-For lets calculate the mean of `df$y` for pattern I.
+Now let's calculate the mean of `df$y` for pattern I:
 
 ```{r}
 foo <- function(df, labelstr) {
@@ -281,7 +279,7 @@ tbl7 <- build_table(lyt7, df)
 tbl7
 ```
 
-Note that `foo` has the variable information hard encoded in the function body. Let's try some alternatives returning to `analyze()`:
+Note that `foo` has the variable information hard-encoded in the function body. Let's try some alternatives returning to `analyze()`:
 
 
 ```{r}
@@ -294,7 +292,7 @@ tbl8 <- build_table(lyt8, df)
 tbl8
 ```
 
-note that the subset of the `y` variable is passed as `x` argument to `mean()`. We could also get the `data.frame` instead of the variable:
+Note that the subset of the `y` variable is passed as the `x` argument to `mean()`. We could also get the `data.frame` instead of the variable:
 
 ```{r}
 lyt9 <- basic_table() %>%
@@ -424,7 +422,7 @@ W
 ```
 
 
-The rows `U`, `u1`, `u2`, ..., `W`, `w1`, `w2`, `w3` are label rows and the other rows (with `mean_sd` and `range` are data rows). Currently we do not have content rows in the table. Content rows summarize the data defined by their splitting (i.e. `V > v1, B`). So if we wanted to add content row at the `r2` split level then we would get:
+The rows `U`, `u1`, `u2`, ..., `W`, `w1`, `w2`, `w3` are label rows and the other rows (with `mean_sd` and `range`) are data rows. Currently we do not have content rows in the table. Content rows summarize the data defined by their splitting (i.e. `V > v1, B`). So if we wanted to add content rows at the `r2` split level then we would get:
 
 
 
@@ -478,7 +476,6 @@ s_cfun_2 <- function(df, labelstr) {
   rcell(nrow(df), format = "xx", label = paste(labelstr, "(n)"))
 }
 
-
 lyt13 <- basic_table() %>%
   split_cols_by("c1") %>%
   split_rows_by("r1") %>%
@@ -491,7 +488,7 @@ tbl13 <- build_table(lyt13, df)
 tbl13
 ```
 
-In the same manner, if we wanted content rows for `r1` split we can do it at as follows:
+In the same manner, if we want content rows for the `r1` split we can do it at as follows:
 
 ```{r}
 lyt14 <- basic_table() %>%
@@ -507,7 +504,7 @@ tbl14 <- build_table(lyt14, df)
 tbl14
 ```
 
-In pagination content rows and label rows get repeated if a page is split in a descendant of a content row. So for example, if we were to split the following table at `***` then :
+In pagination, content rows and label rows get repeated if a page is split in a descendant of a content row. So, for example, if we were to split the following table at `***`:
 
 
 ```
@@ -523,7 +520,7 @@ U
      range    s_range(<>)    s_range(<>)    s_range(<>)
 ```
 
-we would get the following two tables:
+Then we would get the following two tables:
 
 
 

--- a/vignettes/title_footer.Rmd
+++ b/vignettes/title_footer.Rmd
@@ -155,7 +155,7 @@ is identical to the above, when done within a content function.
 ## Annotating an Existing Table with Referential Footnotes
 
 In addition to inserting referential footnotes at tabulation time within
-our analysis functions, we cal also annotate our tables with them
+our analysis functions, we can also annotate our tables with them
 post-hoc.
 
 This is also the only way to add footnotes to **column** labels,
@@ -193,12 +193,12 @@ tbl2
 
 
 We do this with the `fnotes_at_path<-` function which accepts a row
-path, a column path, and a value for *the full set of footnotes for
+path, a column path, and a value for the full set of footnotes for
 the defined locations (`NULL` or a `character` vector).
 
 A non-`NULL` row path with a `NULL` column path specifies the footnote(s)
 should be attached to the row, while `NULL` row path with non-`NULL`
-column path indicates they go with the column. Both being non-null
+column path indicates they go with the column. Both being non-`NULL`
 indicates a cell (and must resolve to an individual cell).
 
 ```{r}
@@ -213,11 +213,11 @@ fnotes_at_path(tbl2, rowpath = NULL, c("ARM", "B: Placebo")) <- c("this is a pla
 tbl2
 ```
 
-Note to step into the content table row we must add that to the path, even though we didn't
+Note to step into a content row we must add that to the path, even though we didn't
 need it to put a footnote on the full row.
 
-Currently, content row by default are named with the *label* rather than *name*, of the 
-corresponding facet. This is reflected in the output of, e.g., `row_paths_summary`
+Currently, content rows by default are named with the *label* rather than *name* of the 
+corresponding facet. This is reflected in the output of, e.g., `row_paths_summary`.
 
 ```{r}
 row_paths_summary(tbl2)


### PR DESCRIPTION
Reviewed the following 5 vignettes and made the following changes:

title_footer:
- corrected typos

sorting_pruning:
- corrected typos
- improved formatting
- corrected grammar for better readability

format_precedence (more changes in this vignette since it is new):
- changed "formats precedence" to "format precedence"
- corrected grammar for better readability
- updated formatting to be more consistent with other vignettes

baseline:
- hid library load messages
- corrected grammar for better readability

tabulation_concepts:
- corrected typos
- hid library load messages
- corrected grammar for better readability

Also fixed a typo and hid library load messages in README.
