### PR TITLE
Add a releaser workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+---
+name: Release 🎈
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build package 🎁
+    needs: release
+    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      skip-r-cmd-check: true
+      skip-r-cmd-install: true
+  docs:
+    name: Pkgdown Docs 📚
+    needs: release
+    uses: insightsengineering/r.pkg.template/.github/workflows/pkgdown.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      default-landing-page: latest-tag
+  validation:
+    name: R Package Validation report 📃
+    needs: release
+    uses: insightsengineering/r.pkg.template/.github/workflows/validation.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+  release:
+    name: Create release 🎉
+    uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
This auto-generates releases and release artifacts on tag creation.

When a new tag is created, this workflow:

1. Creates a GitHub release with release notes obtained from the `NEWS.md` file for that release
2. Creates a new version of docs on GitHub Pages and adds the release to the dropdown in the `pkgdown` website
3. Builds a PDF validation report that is attached to the release
4. Attaches the artifact resulting from `R CMD build` to the release.