### PR TITLE
Automated version bumping

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,3 +47,9 @@ jobs:
     name: Version Check 🏁
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: insightsengineering/r.pkg.template/.github/workflows/version.yaml@main
+  vbump:
+    name: Version Bump 🤜🤛
+    if: github.event_name == 'push'
+    uses: insightsengineering/r.pkg.template/.github/workflows/version-bump.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}


### PR DESCRIPTION
The bot will auto-bump the "dev" version on push to `main`. If you want to skip this (for example during a release or if you want a custom version), make sure to add `[skip vbump]` in your PR title or your merge commit message when merging the PR.
Closes #620 
