### PR TITLE
Remove JunitReporter

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,2 @@
 library(testthat)
-test_check("rtables", reporter = JunitReporter$new(file = "unit_test_results.xml"))
+test_check("rtables", reporter = "check")


### PR DESCRIPTION
This is the only place where we use JunitReporter. Last edit was [3 years ago](https://github.com/insightsengineering/rtables/commit/46b389daae19c9acfd728fe0f5644425dce93301) and it mention CircleCI which we abandoned.
This has implication on testing package via `rcmdcheck`. Using JunitReporter I got:
```
* checking tests ...
  Running ‘testthat.R’
 ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
      matches
  The following objects are masked from 'package:stats':
      filter, lag
  The following objects are masked from 'package:base':
      intersect, setdiff, setequal, union
  Error: Test failures
```

Whereas using "check" I got meaningful information:
```
* checking tests ...
  Running ‘testthat.R’
 ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
   1. └─formatters::export_as_rtf(tbl, file = tmpf) at test-exporters.R:251:4
   2.   └─base::lapply(...)
   3.     └─formatters (local) FUN(X[[i]], ...)
   4.       ├─r2rtf::rtf_encode(...)
   5.       │ └─r2rtf:::.rtf_encode_table(tbl)
   6.       │   ├─base::paste(...)
   7.       │   └─r2rtf:::.as_rtf_color(tbl)
   8.       │     └─r2rtf:::.color_used(tbl)
   9.       └─formatters::mpf_to_rtf(...)
  
  [ FAIL 1 | WARN 1 | SKIP 0 | PASS 722 ]
  Error: Test failures
```