### PR TITLE
Fix row info when indentation is `FALSE` in `matrix_form`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,9 +10,10 @@
  * Fixed edge case bug in `as_result_df` where rows of the table have only `"root"` as path index.
  * Fixed `sort_at_path` pathing to ignore leading `"root"` element (regardless of actual root element name) to match current `tt_at_path` behavior.
  * Fixed `section_div` for analysis of multiple variables (`AnalyzeMultiVars`).
+ * Fixed mismatch between indentation declared in row info (`mf_rinfo(mf)`) and actual selected indentation from `matrix_form(mf, indent_rownames = FALSE)`.
 
 ### Miscellaneous
-* Removed deprecated functions `add_analyzed_var` and `trim_zero_rows`.
+ * Removed deprecated functions `add_analyzed_var` and `trim_zero_rows`.
 
 ## rtables 0.6.6
 ### New Features

--- a/R/tt_toString.R
+++ b/R/tt_toString.R
@@ -258,7 +258,7 @@ setMethod(
       formats[, 1] <- indent_string(formats[, 1], c(rep(0, nr_header), sr$indent),
         incr = indent_size
       )
-    } else {
+    } else if (NROW(sr) > 0) {
       sr$indent <- rep(0, NROW(sr))
     }
 

--- a/R/tt_toString.R
+++ b/R/tt_toString.R
@@ -254,9 +254,12 @@ setMethod(
       body[, 1] <- indent_string(body[, 1], c(rep(0, nr_header), sr$indent),
         incr = indent_size
       )
+      # why also formats?
       formats[, 1] <- indent_string(formats[, 1], c(rep(0, nr_header), sr$indent),
         incr = indent_size
       )
+    } else {
+      sr$indent <- rep(0, NROW(sr))
     }
 
     col_ref_strs <- matrix(vapply(header_content$footnotes, function(x) {

--- a/tests/testthat/test-matrix_form.R
+++ b/tests/testthat/test-matrix_form.R
@@ -3,7 +3,9 @@ context("matrix_form works")
 test_that("matrix_form works with indent_rownames = FALSE", {
   # Discovered thanks to more stringent indentation checks. See #844 for when it
   # surfaced. Cause: make_row_df does not update mf_rinfo indentation if indent_rownames = FALSE
-  lyt <- basic_table() %>% split_rows_by("ARM") %>% analyze("AGE")
+  lyt <- basic_table() %>%
+    split_rows_by("ARM") %>%
+    analyze("AGE")
   tbl <- build_table(lyt, ex_adsl)
   mf <- matrix_form(tbl, indent_rownames = FALSE)
   expect_equal(mf_rinfo(mf)$indent, rep(0, nrow(tbl)))

--- a/tests/testthat/test-matrix_form.R
+++ b/tests/testthat/test-matrix_form.R
@@ -1,0 +1,11 @@
+context("matrix_form works")
+
+test_that("matrix_form works with indent_rownames = FALSE", {
+  # Discovered thanks to more stringent indentation checks. See #844 for when it
+  # surfaced. Cause: make_row_df does not update mf_rinfo indentation if indent_rownames = FALSE
+  lyt <- basic_table() %>% split_rows_by("ARM") %>% analyze("AGE")
+  tbl <- build_table(lyt, ex_adsl)
+  mf <- matrix_form(tbl, indent_rownames = FALSE)
+  expect_equal(mf_rinfo(mf)$indent, rep(0, nrow(tbl)))
+  expect_silent(out <- toString(mf))
+})


### PR DESCRIPTION
Fixes #844 and https://github.com/insightsengineering/formatters/issues/187

@shajoezhu this is the actual fix