### PR TITLE
Fix bug removing indentation in `as_html`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
  * Fixed `sort_at_path` pathing to ignore leading `"root"` element (regardless of actual root element name) to match current `tt_at_path` behavior.
  * Fixed `section_div` for analysis of multiple variables (`AnalyzeMultiVars`).
  * Fixed mismatch between indentation declared in row info (`mf_rinfo(mf)`) and actual selected indentation from `matrix_form(mf, indent_rownames = FALSE)`.
+ * Fixed bug in `as_html` preventing indentation from being applied in `Viewer` output.
 
 ### Miscellaneous
  * Removed deprecated functions `add_analyzed_var` and `trim_zero_rows`.

--- a/R/as_html.R
+++ b/R/as_html.R
@@ -76,7 +76,7 @@ as_html <- function(x,
 
   stopifnot(is(x, "VTableTree"))
 
-  mat <- matrix_form(x)
+  mat <- matrix_form(x, indent_rownames = TRUE)
 
   nlh <- mf_nlheader(mat)
   nc <- ncol(x) + 1


### PR DESCRIPTION
Closes #861 

Bug caused by https://github.com/insightsengineering/rtables/pull/853 and related PRs.