### PR TITLE
Check for tibble package before using it on tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,5 @@
-library(testthat)
-test_check("rtables", reporter = "check")
+if (requireNamespace("testthat", quietly = TRUE)) {
+  library(testthat)
+  library(rtables)
+  test_check("rtables", reporter = "check")
+}

--- a/tests/testthat/test-default_split_funs.R
+++ b/tests/testthat/test-default_split_funs.R
@@ -249,6 +249,9 @@ test_that("drop_and_remove_levels also works with character variables", {
 })
 
 test_that("trim_levels_to_map split function works", {
+  skip_if_not_installed("tibble")
+  require(tibble, quietly = TRUE)
+  
   map <- data.frame(
     LBCAT = c("CHEMISTRY", "CHEMISTRY", "CHEMISTRY", "IMMUNOLOGY"),
     PARAMCD = c("ALT", "CRP", "CRP", "IGA"),

--- a/tests/testthat/test-lyt-tabulation.R
+++ b/tests/testthat/test-lyt-tabulation.R
@@ -237,6 +237,9 @@ test_that("labelkids parameter works", {
 
 
 test_that("ref_group comparisons work", {
+  skip_if_not_installed("tibble")
+  require(tibble, quietly = TRUE)
+  
   blthing <- basic_table() %>%
     split_cols_by("ARM", ref_group = "ARM1") %>%
     analyze("AGE", show_labels = "hidden") %>%

--- a/tests/testthat/test-printing.R
+++ b/tests/testthat/test-printing.R
@@ -801,6 +801,9 @@ test_that("horizontal separator is propagated from table to print and export", {
 ## higher-level showing ncols works:
 
 test_that("showing higher-level ncols works", {
+  skip_if_not_installed("tibble")
+  require(tibble, quietly = TRUE)
+  
   mydat <- subset(ex_adsl, SEX %in% c("M", "F"))
   mydat$SEX2 <- factor(
     ifelse(

--- a/tests/testthat/test-subset-access.R
+++ b/tests/testthat/test-subset-access.R
@@ -136,6 +136,9 @@ test_rowpaths <- function(tt, visonly = TRUE) {
 
 
 test_that("make_row_df, make_col_df give paths which all work", {
+  skip_if_not_installed("tibble")
+  require(tibble, quietly = TRUE)
+  
   lyt <- basic_table() %>%
     split_cols_by("ARM") %>%
     split_cols_by("SEX", ref_group = "F") %>%


### PR DESCRIPTION
Tests on noSuggests flavor of [r-hub](https://github.com/insightsengineering/rtables/actions/runs/12218600565/job/34084291405) are failing because tibble is not available:

```r
══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test-default_split_funs.R:275:3'): trim_levels_to_map split function works ──
Error in `tribble(~ARM, ~RACE, "A: Drug X", "ASIAN", "A: Drug X", "WHITE", 
    "C: Combination", "BLACK OR AFRICAN AMERICAN", "C: Combination", 
    "NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER")`: could not find function "tribble"
── Error ('test-lyt-tabulation.R:287:3'): ref_group comparisons work ───────────
Error in `tribble(~valname, ~label, ~levelcombo, ~exargs, "A_", "Arm 1", 
    c("A: Drug X"), list(), "B_C", "Arms B & C", c("B: Placebo", 
        "C: Combination"), list())`: could not find function "tribble"
── Error ('test-printing.R:887:3'): showing higher-level ncols works ───────────
Error in `tribble(~valname, ~label, ~levelcombo, ~exargs, "A_C", "Arms A+C", 
    c("A: Drug X", "C: Combination"), list())`: could not find function "tribble"
── Error ('test-subset-access.R:196:3'): make_row_df, make_col_df give paths which all work ──
Error in `tribble(~valname, ~label, ~levelcombo, ~exargs, "A_", "Arm 1", 
    c("A: Drug X"), list(), "B_C", "Arms B & C", c("B: Placebo", 
        "C: Combination"), list())`: could not find function "tribble"

[ FAIL 4 | WARN 0 | SKIP 11 | PASS 923 ]
Error: Test failures
```

This PR adds `skip_if_not_installed` where appropriate and also checks that testthat is available before trying to run checks.