### PR TITLE
Remove lookup-refs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,8 +26,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
       additional-env-vars: |
         _R_CHECK_CRAN_INCOMING_REMOTE_=false
       additional-r-cmd-check-params: --as-cran
@@ -50,8 +48,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
       additional-env-vars: |
         NOT_CRAN=true
       enforce-note-blocklist: true
@@ -73,8 +69,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
       additional-env-vars: |
         NOT_CRAN=true
   linter:
@@ -88,8 +82,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
       auto-update: true
   gitleaks:
     name: gitleaks 💧

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,5 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -69,6 +69,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/formatters


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 

```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CI Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.

formatters was the only package on lookup-refs. It is a dependency required at the version available on CRAN or higher. 