### PR TITLE
Test installation for development versions of dependencies without Remotes field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ URL: https://github.com/insightsengineering/rtables,
     https://insightsengineering.github.io/rtables/
 BugReports: https://github.com/insightsengineering/rtables/issues
 Depends:
-    formatters (>= 0.5.10),
+    formatters (>= 0.5.10.9000),
     magrittr (>= 1.5),
     methods,
     R (>= 2.10)


### PR DESCRIPTION
This is just to illustrate what happens, if your package (`rtables`) depends on a development version of a dependency (in this case `formatters (0.5.10.9000)`.

Installation function tries to pull the package only from the known sources (in this case CRAN). The highest available version on CRAN is 0.5.10. It is pulled, but then it is verified with the DESCRIPTION requirements that state 0.5.10.9000 is needed, and the installation fails. There is no information on where to pull `0.5.10.9000` from. If you would have `Remotes: insightsengineering/formatters` included in the DESCRIPTION, the installation procedure would not fail, and would pull the dependency from GitHub.

```r
remove.packages(c('formatters', 'rtables'))
remotes::install_github('insightsengineering/rtables@test_no_remotes', upgrade = 'never')
```

Output

```r
Using github PAT from envvar GITHUB_PAT. Use `gitcreds::gitcreds_set()` and unset GITHUB_PAT in .Renviron (or elsewhere) if you want to use the more secure git credential store instead.
Downloading GitHub repo insightsengineering/rtables@test_no_remotes
Installing 1 packages: formatters
Installing package into ‘C:/Users/m7pr/AppData/Local/R/win-library/4.4’
(as ‘lib’ is unspecified)
trying URL 'https://cran.rstudio.com/bin/windows/contrib/4.4/formatters_0.5.10.zip'
Content type 'application/zip' length 2805602 bytes (2.7 MB)
downloaded 2.7 MB

package ‘formatters’ successfully unpacked and MD5 sums checked

The downloaded binary packages are in
	C:\Users\kosinsm4\AppData\Local\Temp\RtmpAtTWgB\downloaded_packages
Adding ‘formatters_0.5.10.zip’ to the cache
── R CMD build ──────────────────────────────────────────────────────────────────────────────────────────────────
✔  checking for file 'C:\Users\kosinsm4\AppData\Local\Temp\RtmpAtTWgB\remotes68a83b58c2f\insightsengineering-rtables-3f0550d/DESCRIPTION' (407ms)
─  preparing 'rtables': (340ms)
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts (728ms)
─  checking for empty or unneeded directories
   Omitted 'LazyData' from DESCRIPTION
─  building 'rtables_0.6.11.9002.tar.gz'
   
Installing package into ‘C:/Users/kosinsm4/AppData/Local/R/win-library/4.4’
(as ‘lib’ is unspecified)
* installing *source* package 'rtables' ...
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
Error: package 'formatters' 0.5.10 was found, but >= 0.5.10.9000 is required by 'rtables'
Execution halted
ERROR: lazy loading failed for package 'rtables'
* removing 'C:/Users/kosinsm4/AppData/Local/R/win-library/4.4/rtables'
Warning messages:
1: In utils::install.packages(pkgs = pkgs, lib = lib, repos = myrepos,  :
  installation of package ‘C:/Users/m7pr/AppData/Local/Temp/RtmpAtTWgB/file68a811d31ad2/rtables_0.6.11.9002.tar.gz’ had non-zero exit status
2: In utils::install.packages(pkgs = pkgs, lib = lib, repos = myrepos,  :
  installation of package ‘C:/Users/m7pr/AppData/Local/Temp/RtmpAtTWgB/file68a811d31ad2/rtables_0.6.11.9002.tar.gz’ had non-zero exit status
```